### PR TITLE
chore(pyproject): remove License classifier (PEP 639 conflict)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ keywords = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
-    "License :: Other/Proprietary License",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = ["numpy", "scipy"]


### PR DESCRIPTION
## Wave 1.5a — PEP 639 portfolio sweep

Wave 1 hygiene (merged 2026-04-25 ~08:36 UTC) added the PEP 639 license expression
`license = "LicenseRef-Zer0pa-SAL-7.0"` to `pyproject.toml` without removing the
legacy `License :: Other/Proprietary License` classifier from the `classifiers`
list.

setuptools >= 79 enforces PEP 639's prohibition on coexistence and refuses to
build the package under editable install. This broke `pip install -e .` in CI on
ZPE-Bio, ZPE-FT, ZPE-Geo, and ZPE-Neuro. The other 13 lanes carried the same
latent non-compliance — A.2 (reusable workflow migration onto `uv` + fresh
setuptools) would have surfaced the breakage portfolio-wide.

## Change

Single-line removal in `pyproject.toml`: drop the
`"License :: Other/Proprietary License",` line from the `classifiers` array.
The license expression `license = "LicenseRef-Zer0pa-SAL-7.0"` and
`license-files = ["LICENSE"]` remain authoritative and PEP 639 compliant.

## Verification

- `git diff --stat origin/main...HEAD` — single-line removal in `pyproject.toml`
- CI on this branch is expected to succeed where it previously failed on
  `setuptools.errors.InvalidConfigError: License classifiers have been
  superseded by license expressions`
- Setuptools accepts the license expression alone under PEP 639

## Out of scope

Any other pyproject normalization, source/test changes, version bumps, or
workflow edits — those belong in Wave 1.5b lane briefs.
