### PR TITLE
test(image): align test with STAGED + Posture row pattern

### DIFF
--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -46,7 +46,8 @@ def test_readme_proof_anchors_match_validation_packet() -> None:
         relative_path = anchor.relative_to(ROOT).as_posix()
         assert f"`{relative_path}`" in text
 
-    assert f"| Verdict | {payload['publication_status']} |" in text
-    assert f"| Verification Status | {payload['verification_status']} |" in text
+    assert "| Verdict | STAGED |" in text
+    assert f"| Posture | `{payload['publication_status']}` |" in text
+    assert f"| Verification Status | `{payload['verification_status']}` |" in text
     assert f"| Commit SHA | {payload['git_commit']} |" in text
     assert "| Source | validation/results/fresh_falsification_check.json |" in text


### PR DESCRIPTION
Fixes failing main-branch CI: tests/test_readme_contract.py was asserting the legacy '| Verdict | ready_for_publication_review |' literal line. README has been migrated to the canonical pattern (STAGED in Verdict cell + Posture row with backtick token). Test now asserts the canonical pattern, preserving verification of the proof-artifact tokens.

Cleared by R1+R1.5 README refinement and matches the portfolio-wide pattern (Smell, Prosody, XR all use this).