### PR TITLE
test(image): align all assertions with current README backtick pattern

### DIFF
--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -50,4 +50,4 @@ def test_readme_proof_anchors_match_validation_packet() -> None:
     assert f"| Posture | `{payload['publication_status']}` |" in text
     assert f"| Verification Status | `{payload['verification_status']}` |" in text
     assert f"| Commit SHA | {payload['git_commit']} |" in text
-    assert "| Source | validation/results/fresh_falsification_check.json |" in text
+    assert "| Source | `validation/results/fresh_falsification_check.json` |" in text


### PR DESCRIPTION
Follow-up to PR #11. Fixes remaining failing assertion on Source row. All assertions now match the canonical Verdict cell + adjacent Posture/Verification Status rows + backticked path values.

The `test_readme_proof_anchors_match_validation_packet` test was asserting a bare path for the Source row:
```
| Source | validation/results/fresh_falsification_check.json |
```
but the README uses backtick notation:
```
| Source | `validation/results/fresh_falsification_check.json` |
```

Single assertion updated to match. Local pytest confirms all 3 tests green.