### PR TITLE
chore(image): wave-nr falsifier remediation — re-green README contract

### DIFF
--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -23,6 +23,7 @@ def test_readme_uses_canonical_heading_order() -> None:
         "## Proof Anchors",
         "## Repo Shape",
         "## Quick Start",
+        "## Upcoming Workstreams",
     ]
 
 


### PR DESCRIPTION
## Summary

The Wave-NR Phase 1 PR (#13) appended `## Upcoming Workstreams` to the README without updating `tests/test_readme_contract.py::test_readme_uses_canonical_heading_order`. That left `main` red on CI immediately after merge.

This adds `## Upcoming Workstreams` to the canonical heading list so the contract matches the post-Wave-NR README shape that ships across all 17 ZPE lanes.

## Verification

- Local: `pytest tests/test_readme_contract.py -q` → 3 passed
- CI: pending on this PR

## Falsifier reference

Detected by Wave-NR Phase 2 Portfolio Coherence Falsifier — Check 8 (CI green on main). ZPE-Image was the only lane red on `main` post-Phase-1.