### PR TITLE
test(image): accept upcoming workstreams heading

### DIFF
--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -23,6 +23,7 @@ def test_readme_uses_canonical_heading_order() -> None:
         "## Proof Anchors",
         "## Repo Shape",
         "## Quick Start",
+        "## Upcoming Workstreams",
     ]
 
 


### PR DESCRIPTION
## Summary
- updates the README contract test to include the new `## Upcoming Workstreams` heading added on `main`
- keeps the Wave-NR README content intact and limits the fix to the failing assertion

## Verification
- `python -m build`
- `pytest -q` -> 5 passed
