### PR TITLE
[codex] Move detailed install commands to README end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # ZPE-Image
 
-## Install / Developer Commands
-
-<!-- INSTALL-DX:START -->
-#### Package Install
+## Package Install
 
 Installable package: `python3.11 -m pip install zpe-image`.
 Current release: `0.1.0` on [PyPI](https://pypi.org/project/zpe-image/).
@@ -13,56 +10,9 @@ Source: [Zer0pa/ZPE-Image](https://github.com/Zer0pa/ZPE-Image/).
 python3.11 -m pip install zpe-image
 ```
 
-Import smoke:
+For full install, smoke, source, and developer commands, [click here](#install-developer-commands-detailed).
 
-```bash
-python3.11 - <<'PY'
-import importlib.metadata as md
-import zpe_image_codec
-
-print("zpe-image", md.version("zpe-image"))
-PY
-```
-
-
-CLI smoke:
-
-```bash
-zpe-image-verify --help
-```
-
-Install success only proves package acquisition/import. Product scope, stale PyPI state, platform limits, and blockers remain in the front-door sections below.
-- PyPI copy is stale or pending refresh; install success is not product readiness.
-<!-- INSTALL-DX:END -->
-
-#### Evidence Anchors
-
-| Evidence | Current truth |
-|---|---|
-| Architecture | IMAGE_STREAM |
-| Encoding | IMAGE_SPARSE_GEOMETRY_V1 |
-| Proof Anchors | 3 |
-| Authority Source | `proofs/artifacts/fresh_falsification_packet.json` |
-| Runtime Package | `src/zpe_image_codec` |
-| Verification packet | `proofs/manifests/CURRENT_VERIFICATION_PACKET.md` |
-| Proof packet | `proofs/artifacts/fresh_falsification_packet.json` |
-| Validation result | `validation/results/fresh_falsification_check.json` |
-| Verdict | STAGED |
-| Posture | `ready_for_publication_review` |
-| Verification Status | `fresh_falsification_ready` |
-| Commit SHA | c1ed7abaa560 |
-| Source | `validation/results/fresh_falsification_check.json` |
-
-#### Quick Start
-
-```bash
-python3 -m venv .venv
-. .venv/bin/activate
-python3 -m pip install --upgrade pip
-python3 -m pip install '.[dev]'
-zpe-image-verify --output validation/results/fresh_falsification_check.local.json
-pytest -q
-```
+---
 
 <table width="100%">
 <tr>
@@ -334,3 +284,71 @@ pytest -q
 </td>
 </tr>
 </table>
+
+---
+
+<a id="install-developer-commands-detailed"></a>
+
+## Install / Developer Commands Detailed
+
+<!-- INSTALL-DX:START -->
+#### Package Install
+
+Installable package: `python3.11 -m pip install zpe-image`.
+Current release: `0.1.0` on [PyPI](https://pypi.org/project/zpe-image/).
+Source: [Zer0pa/ZPE-Image](https://github.com/Zer0pa/ZPE-Image/).
+
+```bash
+python3.11 -m pip install zpe-image
+```
+
+Import smoke:
+
+```bash
+python3.11 - <<'PY'
+import importlib.metadata as md
+import zpe_image_codec
+
+print("zpe-image", md.version("zpe-image"))
+PY
+```
+
+
+CLI smoke:
+
+```bash
+zpe-image-verify --help
+```
+
+Install success only proves package acquisition/import. Product scope, stale PyPI state, platform limits, and blockers remain in the front-door sections below.
+- PyPI copy is stale or pending refresh; install success is not product readiness.
+<!-- INSTALL-DX:END -->
+
+#### Evidence Anchors
+
+| Evidence | Current truth |
+|---|---|
+| Architecture | IMAGE_STREAM |
+| Encoding | IMAGE_SPARSE_GEOMETRY_V1 |
+| Proof Anchors | 3 |
+| Authority Source | `proofs/artifacts/fresh_falsification_packet.json` |
+| Runtime Package | `src/zpe_image_codec` |
+| Verification packet | `proofs/manifests/CURRENT_VERIFICATION_PACKET.md` |
+| Proof packet | `proofs/artifacts/fresh_falsification_packet.json` |
+| Validation result | `validation/results/fresh_falsification_check.json` |
+| Verdict | STAGED |
+| Posture | `ready_for_publication_review` |
+| Verification Status | `fresh_falsification_ready` |
+| Commit SHA | c1ed7abaa560 |
+| Source | `validation/results/fresh_falsification_check.json` |
+
+#### Quick Start
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install '.[dev]'
+zpe-image-verify --output validation/results/fresh_falsification_check.local.json
+pytest -q
+```


### PR DESCRIPTION
## Summary
- keep a minimal package/boundary cue at the top of the README
- move the full install, smoke, source, and developer commands to a detailed section at the end
- add a stable top jump link to the detailed section

## Validation
- README-only change
- original product front-door body is preserved byte-for-byte
- original install/developer content is preserved byte-for-byte in the new detailed section
